### PR TITLE
no entry type 'BasementGuy', returns empty dialogue. 

### DIFF
--- a/Scripts/Mobiles/NPCs/Vendors/BasementGuy.cs
+++ b/Scripts/Mobiles/NPCs/Vendors/BasementGuy.cs
@@ -63,7 +63,7 @@ namespace Server.Mobiles
 				{
 					if ( ! mobile.HasGump( typeof( SpeechGump ) ) )
 					{
-						mobile.SendGump(new SpeechGump( "The Right Survival Gear", SpeechFunctions.SpeechText( m_Giver.Name, m_Mobile.Name, "BasementGuy" ) ));
+						mobile.SendGump(new SpeechGump( "The Right Survival Gear", SpeechFunctions.SpeechText( m_Giver.Name, m_Mobile.Name, "Provisioner" ) ));
 					}
 				}
             }


### PR DESCRIPTION
Changed to 'Provisioner' - now working as originally intended.