### PR TITLE
feat: MacOS dev experience 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 RunUO.exe
 Logs
 Saves
-Backups
+ACC Backups

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vscode
+RunUO.exe
+Logs
+Saves
+Backups

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,4 @@
+brew docker
+brew docker-buildx
+brew orbstack
+brew mono

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
-brew docker
-brew docker-buildx
-brew orbstack
-brew mono
+brew "docker"
+brew "docker-buildx"
+brew "mono"
+
+cask "orbstack"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Tested on mono:6.12.0.182
+FROM mono:6.12
+
+# Save time
+RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup
+# Save space
+RUN echo "Acquire::http {No-Cache=True;};" > /etc/apt/apt.conf.d/no-cache
+# Add the zlib1g-dev package
+RUN echo "deb http://security.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list
+RUN apt-get -qq update && apt-get -qq --yes install zlib1g-dev
+
+# Take only what the server needs
+COPY ./Data/ /opt/Ultima-Adventures/Data/
+COPY ./Files/ /opt/Ultima-Adventures/Files/
+# If you'd like to be able to modify the scripts without having to rebuild the image, then remove the copy of the scripts
+# and bind mount your scripts folder from the host - like the Logs & Saves.
+COPY ./Scripts/ /opt/Ultima-Adventures/Scripts/
+COPY ./Server/ /opt/Ultima-Adventures/Server/
+COPY ./*.dll /opt/Ultima-Adventures/
+COPY ./*.exe /opt/Ultima-Adventures/
+
+WORKDIR /opt/Ultima-Adventures
+
+CMD ["mono", "./RunUO.exe"]
+
+# Port is set in "Scripts/Server Functions/Misc/SocketOptions.cs"
+EXPOSE 2593/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# docker buildx build --tag ultima-adventures --progress auto .
+# docker run -it -p 2593:2593 -v ./Backups:/opt/Ultima-Adventures/Backups -v ./Logs:/opt/Ultima-Adventures/Logs -v ./Saves:/opt/Ultima-Adventures/Saves ultima-adventures
+
 # Tested on mono:6.12.0.182
 FROM mono:6.12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # docker buildx build --tag ultima-adventures --progress auto .
-# docker run -it -p 2593:2593 -v ./Backups:/opt/Ultima-Adventures/Backups -v ./Logs:/opt/Ultima-Adventures/Logs -v ./Saves:/opt/Ultima-Adventures/Saves ultima-adventures
+# docker run -it -p 2593:2593 -v "./ACC Backups:/opt/Ultima-Adventures/ACC Backups" -v ./Logs:/opt/Ultima-Adventures/Logs -v ./Saves:/opt/Ultima-Adventures/Saves ultima-adventures
 
 # Tested on mono:6.12.0.182
 FROM mono:6.12

--- a/Documentation/How to run or compile linux.txt
+++ b/Documentation/How to run or compile linux.txt
@@ -1,11 +1,5 @@
-1. you need to change the directory in /scripts/MyserverSettings.cs
-Change return @"C:\Ultima-Adventures\Files";
-To return @"./Files";
-
 install mono (required)
 
 then run this in the main directory
 
-mcs -optimize+ -unsafe -t:exe -out:RunUO.exe -win32icon:Server/runuo.ico -nowarn:219,414 -d:NEWTIMERS -d:NEWPARENT -d:MONO -reference:System.Drawing -recurse:Server/*.cs 
-
-OR just run the linux executable with ./LinuxExecutable.exe
+mcs -optimize+ -unsafe -t:exe -out:RunUO.exe -win32icon:Server/runuo.ico -nowarn:219,414 -d:NEWTIMERS -d:NEWPARENT -d:MONO -reference:System.Drawing -r:System.Drawing.Common.dll -r:System.Runtime.Remoting.dll -r:UOArchitectInterface.dll -r:OrbServerSDK.dll -recurse:Server/*.cs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: run stop
+
+compile:
+	mcs -optimize+ -unsafe -t:exe -out:RunUO.exe -win32icon:Server/runuo.ico -nowarn:219,414 -d:NEWTIMERS -d:NEWPARENT -d:MONO -reference:System.Drawing -r:System.Drawing.Common.dll -r:System.Runtime.Remoting.dll -r:UOArchitectInterface.dll -r:OrbServerSDK.dll -recurse:Server/*.cs
+
+build:
+	docker buildx build --tag ultima-adventures --progress auto .
+
+run:
+	docker run -it -p 2593:2593 -v ./Backups:/opt/Ultima-Adventures/Backups -v ./Logs:/opt/Ultima-Adventures/Logs -v ./Saves:/opt/Ultima-Adventures/Saves ultima-adventures
+
+stop:
+	docker stop ultima-adventures
+
+dev-deps:
+	brew bundle install
+
+all: dev-deps compile build run
+
+rebuild: stop compile build run

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 	docker buildx build --tag ultima-adventures --progress auto .
 
 run:
-	docker run -it -p 2593:2593 -v ./Backups:/opt/Ultima-Adventures/Backups -v ./Logs:/opt/Ultima-Adventures/Logs -v ./Saves:/opt/Ultima-Adventures/Saves ultima-adventures
+	docker run -it -p 2593:2593 -v "./ACC Backups:/opt/Ultima-Adventures/ACC Backups" -v ./Logs:/opt/Ultima-Adventures/Logs -v ./Saves:/opt/Ultima-Adventures/Saves ultima-adventures
 
 stop:
 	docker stop ultima-adventures

--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ Alternatively, you can just download the entire package and not bother with clon
 All the best to the UO community, I hope to keep playing this amazing game for many more years to come.  Feel free to clone and revise as you wish!
 
 Note:  This code is completely open for you to use in any way you want.  Because the code depends on Runuo, Servuo, Djeryv, myself and hundreds of other contributors, we ask that you return the favor and make your server code/changes freely available.  The codebase benefits overall when everyone adds to it in their own personal capacity.
+
+### MacOs Containerized Linux Development
+
+Steps to get started:
+1. Ensure you have `brew` installed
+2. clone repo, make it your working directory
+3. `make dev-deps` to install contents of Brewfile
+4. Start the Orbstack agent, `⌘ + Space` to open spotlight and type Orbstack.
+5. `make compile` to build the linux binary you'll need
+6. `make build` to build the containerized image
+7. `make run` to start the container and boot up the server!
+8. Changes in code can be re-loaded into the container via `make rebuild`


### PR DESCRIPTION
# Rationale:

I know I could use my bootcamp installation to get a development flow for this repo going in Windows, but I prefer working in MacOS so I took a run at making it easier as a first step. 

# Changes
- updated `how to run or compile on linux.txt` directions (everyone benefits from this change)
- init Brewfile for dependency installs
- Dockerfile cribbed from #9 (rad work by @cgreen)
- Makefile to tie it all together
- README update

## Unrelated Changes
- init .gitignore 

# Notes
- Thanks to the DockerFile from the above PR, the data from your server will persist in the local directory, as the image uses bind mounts to avoid ephemeral data loss. 
